### PR TITLE
Fix RecursionError when pickling symbolic models

### DIFF
--- a/pytorch_symbolic/symbolic_data.py
+++ b/pytorch_symbolic/symbolic_data.py
@@ -121,7 +121,7 @@ class SymbolicData:
                 logging.debug(f"Adding new operator to {self.__class__.__name__}: {operator}")
 
                 def factory(op):
-                    return lambda self, *args, **kwds: self.__getattr__(op)(*args, **kwds)
+                    return lambda self, *args, **kwds: self._get_attr_node(op)(*args, **kwds)
 
                 setattr(self.__class__, operator, factory(operator))
 
@@ -271,14 +271,23 @@ class SymbolicData:
     def __hash__(self):
         return id(self)
 
+    def _get_attr_node(self, item):
+        """Register a node that extracts an attribute of the underlying value."""
+        return self(useful_layers.GetAttr(item))
+
     def __getattr__(self, item):
-        if (
-            hasattr(self.v, item)
-            and item != "__torch_function__"  # because pytorch is wrapping `+` and other operators
-        ):
-            return self(useful_layers.GetAttr(item))
+        if item.startswith("_"):
+            # Private and dunder lookups must fail fast instead of being redirected to the
+            # underlying value. Redirecting them breaks protocols that probe for optional
+            # attributes before the instance is fully initialized: unpickling, for example,
+            # probes for `__setstate__` while `_value` does not exist yet, which sent
+            # `__getattr__` into infinite recursion through the `v` property.
+            # This also covers `__torch_function__`, because pytorch wraps `+` and other operators.
+            raise AttributeError(item)
+        if hasattr(self.v, item):
+            return self._get_attr_node(item)
         else:
-            raise AttributeError
+            raise AttributeError(item)
 
 
 class SymbolicCallable(SymbolicData):

--- a/pytorch_symbolic/symbolic_model.py
+++ b/pytorch_symbolic/symbolic_model.py
@@ -52,6 +52,19 @@ class DetachedSymbolicModel(nn.Module):
         exec(self._generated_forward_source, {}, scope)
         self.forward = MethodType(scope["forward"], self)
 
+    def __getstate__(self):
+        # The generated forward is created with `exec` and cannot be pickled.
+        # It is recreated in `__setstate__` from `_generated_forward_source`.
+        state = super().__getstate__()
+        state.pop("forward", None)
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        scope = {"self": self}
+        exec(self._generated_forward_source, {}, scope)
+        self.forward = MethodType(scope["forward"], self)
+
 
 class SymbolicModel(nn.Module):
     def __init__(
@@ -261,6 +274,20 @@ class SymbolicModel(nn.Module):
         scope = {"self": self}
         exec(self._generated_forward_source, {}, scope)
         self.forward = MethodType(scope["forward"], self)
+
+    def __getstate__(self):
+        # The codegen forward is created with `exec` and cannot be pickled.
+        # It is recreated in `__setstate__` from `_generated_forward_source`.
+        state = super().__getstate__()
+        state.pop("forward", None)
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        if self._enable_forward_codegen:
+            scope = {"self": self}
+            exec(self._generated_forward_source, {}, scope)
+            self.forward = MethodType(scope["forward"], self)
 
     def _used_nodes(self) -> Set[SymbolicData]:
         """Return a set of all nodes used in this model."""

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,70 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+import copy
+import pickle
+
+import torch
+from torch import nn
+
+from pytorch_symbolic import Input, SymbolicModel
+
+
+def create_model(enable_forward_codegen=None):
+    torch.manual_seed(42)
+    inputs = Input(shape=(8,))
+    x = nn.Linear(8, 16)(inputs)
+    x = nn.ReLU()(x)
+    outputs = nn.Linear(16, 4)(x)
+    return SymbolicModel(inputs=inputs, outputs=outputs, enable_forward_codegen=enable_forward_codegen)
+
+
+def test_pickle_roundtrip():
+    model = create_model()
+    data = torch.rand(5, 8)
+
+    restored = pickle.loads(pickle.dumps(model))
+    assert torch.equal(model(data), restored(data))
+
+
+def test_pickle_roundtrip_codegen():
+    model = create_model(enable_forward_codegen=True)
+    data = torch.rand(5, 8)
+
+    restored = pickle.loads(pickle.dumps(model))
+    assert torch.equal(model(data), restored(data))
+    # The restored model must use the generated forward, not fall back to graph replay
+    assert restored.forward.__func__ is not SymbolicModel.forward
+
+
+def test_pickle_roundtrip_no_codegen():
+    model = create_model(enable_forward_codegen=False)
+    data = torch.rand(5, 8)
+
+    restored = pickle.loads(pickle.dumps(model))
+    assert torch.equal(model(data), restored(data))
+
+
+def test_pickle_roundtrip_detached():
+    model = create_model()
+    detached = model.detach_from_graph()
+    data = torch.rand(5, 8)
+
+    restored = pickle.loads(pickle.dumps(detached))
+    assert torch.equal(detached(data), restored(data))
+
+
+def test_deepcopy_model():
+    model = create_model()
+    data = torch.rand(5, 8)
+
+    model_copy = copy.deepcopy(model)
+    assert torch.equal(model(data), model_copy(data))
+
+
+def test_private_attribute_probe_does_not_create_nodes():
+    x = Input(shape=(8,))
+    assert len(x.children) == 0
+
+    assert not hasattr(x, "_nonexistent_attribute")
+    assert not hasattr(x, "__wrapped__")
+    assert len(x.children) == 0


### PR DESCRIPTION
Pickling any `SymbolicModel` (or `SymbolicData`) currently crashes on load:

```python
import pickle, torch
from torch import nn
from pytorch_symbolic import Input, SymbolicModel

inputs = Input(shape=(8,))
outputs = nn.Linear(8, 4)(inputs)
model = SymbolicModel(inputs, outputs)
pickle.loads(pickle.dumps(model))  # RecursionError
```

There are two independent problems behind this.

**1. `__getattr__` recursion.** During unpickling the instance `__dict__` is not restored yet, so pickle's probe for `__setstate__` reaches `SymbolicData.__getattr__`, which evaluates `hasattr(self.v, item)`; the `v` property reads `self._value`, which is also missing, re-entering `__getattr__` forever.

`__getattr__` now raises `AttributeError` immediately for any name starting with `_`. This also subsumes the existing `__torch_function__` special case, and as a side benefit it stops `hasattr` probes for private names from silently registering `GetAttr` nodes in the graph. The dynamically installed operators (`__and__`, `__or__`, … and all operators on non-tensor Symbolic Data) used to route through `__getattr__` with dunder names, so they were redirected to a small private helper `_get_attr_node`; public attribute access is unchanged.

**2. The codegen forward does not survive pickling.** It is a bound method created with `exec`, which pickle reconstructs via `getattr(obj, "forward")` — yielding the class-level `forward` instead. As a result a restored `SymbolicModel` silently fell back to graph replay, and a restored `DetachedSymbolicModel` had no usable forward at all (`NotImplementedError` on call). Both classes now drop the bound method in `__getstate__` and recreate it from `_generated_forward_source` in `__setstate__`.

All existing tests pass in the three codegen configurations from `check.sh`. Six new tests in `tests/test_serialization.py` cover pickle roundtrips (default / codegen / no-codegen / detached), deepcopy, and the no-graph-mutation guarantee for private attribute probes.
