### PR TITLE
Propagate batch_size_known from all parents, not just the first

### DIFF
--- a/pytorch_symbolic/symbolic_data.py
+++ b/pytorch_symbolic/symbolic_data.py
@@ -156,7 +156,7 @@ class SymbolicData:
             parents=parents,
             layer=layer,
             depth=new_depth,
-            batch_size_known=self.batch_size_known,
+            batch_size_known=all(parent.batch_size_known for parent in parents),
             custom_name=custom_name,
         )
         for parent in parents:

--- a/tests/test_batch_size_known.py
+++ b/tests/test_batch_size_known.py
@@ -1,0 +1,28 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+from pytorch_symbolic import Input
+
+
+def test_batch_size_known_order_independent():
+    a = Input(batch_shape=(4, 8))
+    b = Input(shape=(8,))
+    assert a.batch_size_known
+    assert not b.batch_size_known
+
+    assert not (a + b).batch_size_known
+    assert not (b + a).batch_size_known
+
+
+def test_batch_size_known_propagation():
+    a = Input(batch_shape=(4, 8))
+    b = Input(batch_shape=(4, 8))
+    assert (a + b).batch_size_known
+
+    c = Input(shape=(8,))
+    d = Input(shape=(8,))
+    assert not (c + d).batch_size_known
+
+    # A single unknown batch size anywhere poisons all downstream nodes
+    x = (a + b) + c
+    assert not x.batch_size_known
+    assert not (x + a).batch_size_known


### PR DESCRIPTION
The `SymbolicData` docstring says batch size is known "iff all parents' batch sizes are known", but `apply_module` inherited the flag from the first parent only, making the result depend on operand order:

```python
from pytorch_symbolic import Input

a = Input(batch_shape=(4, 8))   # batch size known
b = Input(shape=(8,))           # batch size unknown
print((a + b).batch_size_known)  # True
print((b + a).batch_size_known)  # False  -- same node, different operand order
```

This changes the propagation to `all(parent.batch_size_known for parent in parents)`, matching the documented semantics. The flag is only consumed by `summary()`, which now correctly prints `None` for the batch dimension of nodes that mix known- and unknown-batch parents.

2 new tests in `tests/test_batch_size_known.py` cover order independence and propagation.
