### PR TITLE
Fix draw_graph(show=True) doing nothing

### DIFF
--- a/pytorch_symbolic/graph_algorithms.py
+++ b/pytorch_symbolic/graph_algorithms.py
@@ -337,9 +337,9 @@ def draw_graph(
         fig.set_size_inches(*figsize)
 
     fig.tight_layout()
+    if show:
+        plt.show()
     return fig
-    # if show:
-    #     fig.show()
 
 
 def sort_graph_and_check_DAG(nodes: set[SymbolicData]) -> list[SymbolicData]:

--- a/tests/test_draw_graph.py
+++ b/tests/test_draw_graph.py
@@ -1,0 +1,66 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+from torch import nn
+
+from pytorch_symbolic import Input, SymbolicModel, graph_algorithms
+
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+    import networkx  # noqa: F401
+    import scipy  # noqa: F401
+
+    matplotlib.use("Agg")
+    VISUALIZATION_AVAILABLE = True
+except ImportError:
+    VISUALIZATION_AVAILABLE = False
+
+
+def create_model():
+    inputs = Input(shape=(8,))
+    outputs = nn.Linear(8, 4)(inputs)
+    return SymbolicModel(inputs=inputs, outputs=outputs)
+
+
+def test_draw_graph_returns_figure():
+    if not VISUALIZATION_AVAILABLE:
+        return
+    model = create_model()
+
+    fig = graph_algorithms.draw_graph(model=model)
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_draw_graph_show_calls_pyplot_show():
+    if not VISUALIZATION_AVAILABLE:
+        return
+    model = create_model()
+
+    show_calls = []
+    original_show = plt.show
+    plt.show = lambda *args, **kwds: show_calls.append(args)
+    try:
+        fig = graph_algorithms.draw_graph(model=model, show=True)
+    finally:
+        plt.show = original_show
+
+    assert len(show_calls) == 1
+    plt.close(fig)
+
+
+def test_draw_graph_show_false_does_not_call_show():
+    if not VISUALIZATION_AVAILABLE:
+        return
+    model = create_model()
+
+    show_calls = []
+    original_show = plt.show
+    plt.show = lambda *args, **kwds: show_calls.append(args)
+    try:
+        fig = graph_algorithms.draw_graph(model=model, show=False)
+    finally:
+        plt.show = original_show
+
+    assert len(show_calls) == 0
+    plt.close(fig)


### PR DESCRIPTION
`draw_graph` has a `show` argument documented as "Call matplotlib.pyplot.show", but passing `show=True` doesn't display anything. The implementation was commented out and, on top of that, placed *after* the `return fig`, so it was unreachable — and it used `fig.show()`, which is a no-op without a running GUI event loop.

This wires it up properly: `plt.show()` is called before returning the figure when `show=True`.

I added a small test module (using the `Agg` backend, and skipped when the optional viz deps aren't installed) that checks a figure is returned and that `show=True` / `show=False` do / don't call `pyplot.show`.
