### PR TITLE
Use ast.literal_eval instead of eval for config env vars

### DIFF
--- a/pytorch_symbolic/config.py
+++ b/pytorch_symbolic/config.py
@@ -1,5 +1,6 @@
 #  Copyright (c) 2022 Szymon Mikler
 
+import ast
 import os
 
 from .symbolic_api_2 import enable_symbolic_api_2_for_new_modules
@@ -7,7 +8,7 @@ from .symbolic_api_2 import enable_symbolic_api_2_for_new_modules
 
 def read_from_env(name, default):
     if name in os.environ:
-        value = eval(os.environ[name], {}, {})
+        value = ast.literal_eval(os.environ[name])
     else:
         value = default
     return value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+import os
+
+from pytorch_symbolic.config import read_from_env
+
+TEST_ENTRY = "PYTORCH_SYMBOLIC_TEST_ENTRY"
+
+
+def test_read_from_env_parses_literals():
+    try:
+        os.environ[TEST_ENTRY] = "False"
+        assert read_from_env(TEST_ENTRY, True) is False
+
+        os.environ[TEST_ENTRY] = "True"
+        assert read_from_env(TEST_ENTRY, False) is True
+
+        os.environ[TEST_ENTRY] = "50"
+        assert read_from_env(TEST_ENTRY, 0) == 50
+    finally:
+        del os.environ[TEST_ENTRY]
+
+
+def test_read_from_env_returns_default():
+    assert TEST_ENTRY not in os.environ
+    assert read_from_env(TEST_ENTRY, 123) == 123
+
+
+def test_read_from_env_rejects_expressions():
+    raised = False
+    try:
+        os.environ[TEST_ENTRY] = "__import__('os').getcwd()"
+        read_from_env(TEST_ENTRY, None)
+    except ValueError:
+        raised = True
+    finally:
+        del os.environ[TEST_ENTRY]
+    assert raised


### PR DESCRIPTION
`read_from_env` parses configuration environment variables with `eval()`:

```python
value = eval(os.environ[name], {}, {})
```

The values it ever needs to read are plain literals (`True`, `False`, `50`), so this is more power than required — anything in those env vars gets executed. `ast.literal_eval` parses all the documented values identically while only ever accepting literals, so a stray or malicious value can't run code during import.

Behavior is unchanged for every value the library actually uses. Added tests covering literal parsing, the default path, and that a non-literal expression is now rejected instead of executed.
