### PR TITLE
Fix SymbolicFactory cache collision for same-named types

### DIFF
--- a/pytorch_symbolic/symbolic_data.py
+++ b/pytorch_symbolic/symbolic_data.py
@@ -499,13 +499,13 @@ _SYMBOLIC_FACTORY_CACHE = {}
 
 def SymbolicFactory(dtype):
     global _SYMBOLIC_FACTORY_CACHE
-    dtype_name = dtype.__name__
 
-    if dtype_name not in _SYMBOLIC_FACTORY_CACHE:
-        logging.debug(f"New underlying data detected: {dtype_name}!")
-        cls = type(f"SymbolicData({dtype_name})", (SymbolicData,), {})
-        _SYMBOLIC_FACTORY_CACHE[dtype_name] = cls
-    return _SYMBOLIC_FACTORY_CACHE[dtype_name]
+    # Cache by the type object itself: distinct types can share a name
+    if dtype not in _SYMBOLIC_FACTORY_CACHE:
+        logging.debug(f"New underlying data detected: {dtype.__name__}!")
+        cls = type(f"SymbolicData({dtype.__name__})", (SymbolicData,), {})
+        _SYMBOLIC_FACTORY_CACHE[dtype] = cls
+    return _SYMBOLIC_FACTORY_CACHE[dtype]
 
 
 def Input(

--- a/tests/test_symbolic_factory.py
+++ b/tests/test_symbolic_factory.py
@@ -1,0 +1,35 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+from pytorch_symbolic import CustomInput
+from pytorch_symbolic.symbolic_data import SymbolicFactory
+
+
+def make_class(value):
+    class Payload:
+        def __init__(self):
+            self.value = value
+
+    return Payload
+
+
+def test_same_name_different_types_get_distinct_classes():
+    cls_a = make_class(1)
+    cls_b = make_class(2)
+    assert cls_a.__name__ == cls_b.__name__
+    assert cls_a is not cls_b
+
+    assert SymbolicFactory(cls_a) is not SymbolicFactory(cls_b)
+
+
+def test_same_type_reuses_cached_class():
+    cls = make_class(3)
+    assert SymbolicFactory(cls) is SymbolicFactory(cls)
+
+
+def test_custom_input_with_same_name_types():
+    a = CustomInput(make_class(1)())
+    b = CustomInput(make_class(2)())
+
+    assert type(a) is not type(b)
+    assert a.v.value == 1
+    assert b.v.value == 2


### PR DESCRIPTION
I ran into this while wrapping non-tensor data with `CustomInput`. `SymbolicFactory` caches the `SymbolicData` subclasses it generates, but it keys that cache by `dtype.__name__`:

```python
if dtype_name not in _SYMBOLIC_FACTORY_CACHE:
    cls = type(f"SymbolicData({dtype_name})", (SymbolicData,), {})
    _SYMBOLIC_FACTORY_CACHE[dtype_name] = cls
```

So two genuinely different classes that happen to share a name — e.g. a `Config` defined in two different modules — collide, and the second one silently gets wrapped in the subclass generated for the first.

This keys the cache by the type object itself instead. The name is still used for the generated class's display name, so nothing changes in `repr`/`summary`. Added a couple of tests: two same-named-but-distinct classes now get distinct wrappers, and the same type still reuses its cached wrapper.
