### PR TITLE
Add tests + docs for torch.compile / torch.export compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features:
 * Small extension of PyTorch
 * No dependencies besides PyTorch
 * Produces models entirely compatible with PyTorch
+* Works with `torch.compile` and `torch.export`
 * Overhead free as tested in [benchmarks](docs/benchmarks.md)
 * Reduces the amount of boilerplate code
 * Works well with complex architectures
@@ -61,6 +62,15 @@ _______________________________________________________
 
 **See more examples
 in [Documentation Quick Start](docs/quick_start.md).**
+
+Symbolic models are plain `torch.nn.Module` objects, so they work with modern PyTorch tooling:
+
+```python
+model = SymbolicModel(inputs=inputs, outputs=x)
+compiled_model = torch.compile(model)
+exported_program = torch.export.export(model, (example_input,))
+# ...
+```
 
 ## How to start
 

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -1,0 +1,78 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+import platform
+import sys
+
+import torch
+from torch import nn
+
+from pytorch_symbolic import Input, SymbolicModel
+
+
+def torch_version_at_least(major, minor):
+    version = torch.__version__.split("+")[0].split(".")
+    return (int(version[0]), int(version[1])) >= (major, minor)
+
+
+def compile_supported():
+    # torch.compile is not supported on Windows and requires Python >= 3.8
+    if platform.system() == "Windows":
+        return False
+    if sys.version_info < (3, 8):
+        return False
+    return hasattr(torch, "compile")
+
+
+def export_supported():
+    # torch.export with the stable .module() API is available since torch 2.4
+    return compile_supported() and torch_version_at_least(2, 4)
+
+
+def create_model(enable_forward_codegen=None):
+    torch.manual_seed(42)
+    inputs = Input(shape=(8,))
+    x = nn.Linear(8, 16)(inputs)
+    x = nn.ReLU()(x)
+    outputs = nn.Linear(16, 4)(x)
+    return SymbolicModel(inputs=inputs, outputs=outputs, enable_forward_codegen=enable_forward_codegen)
+
+
+def test_torch_compile_matches_eager():
+    if not compile_supported():
+        return
+    model = create_model()
+    compiled_model = torch.compile(model)
+
+    data = torch.rand(4, 8)
+    assert torch.allclose(model(data), compiled_model(data))
+
+
+def test_torch_compile_no_codegen_matches_eager():
+    if not compile_supported():
+        return
+    model = create_model(enable_forward_codegen=False)
+    compiled_model = torch.compile(model, backend="eager")
+
+    data = torch.rand(4, 8)
+    assert torch.allclose(model(data), compiled_model(data))
+
+
+def test_torch_compile_detached_model():
+    if not compile_supported():
+        return
+    model = create_model()
+    detached_model = model.detach_from_graph()
+    compiled_model = torch.compile(detached_model, backend="eager")
+
+    data = torch.rand(4, 8)
+    assert torch.allclose(model(data), compiled_model(data))
+
+
+def test_torch_export_matches_eager():
+    if not export_supported():
+        return
+    model = create_model()
+
+    data = torch.rand(4, 8)
+    exported_program = torch.export.export(model, (data,))
+    assert torch.allclose(model(data), exported_program.module()(data))


### PR DESCRIPTION
Symbolic models are plain `nn.Module`s, and it turns out they already play nicely with `torch.compile` and `torch.export` — both the generated forward and the graph-replay forward, and also after `detach_from_graph()`. I wanted that pinned down so it doesn't regress.

This adds a small test module exercising:

- `torch.compile(model)` matching eager output (default and `enable_forward_codegen=False`)
- `torch.compile` on a detached model
- `torch.export.export(model, ...)` matching eager

The tests guard themselves where dynamo isn't available (Windows, Python < 3.8, torch builds without `torch.compile` / a stable `torch.export`), so they skip cleanly rather than failing on those CI legs. I also added a short note to the README's feature list and a snippet showing the two calls.
