### PR TITLE
Support Keras-style None dynamic dimensions in Input

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -110,6 +110,7 @@ Using Pytorch Symbolic, you can perform much more complicated operations.
 	* `inputs = Input(shape=(C, H, W))`
 	* `inputs = Input(shape=(C, H, W), batch_size=B)`
 	* `inputs = Input(batch_shape=(B, C, H, W))`
+	* `inputs = Input(shape=(C, None, None))` for dynamic height and width, like in Keras
 2. Register new modules in the graph. There are a few ways:
 	* `outputs = inputs(layer)`
 	* `outputs = layer(inputs)`
@@ -129,6 +130,33 @@ Using Pytorch Symbolic, you can perform much more complicated operations.
 8. Use `model` as a normal PyTorch `nn.Module`. It's 100% compatible.
    When using the model,
    all the operations performed on Symbolic Data will be replayed on the real data.
+
+### Dynamic dimensions
+
+If a dimension of your data varies between batches, e.g. image size or sequence length,
+mark it with `None`, like in Keras. It will be displayed as `None` in `.shape` and
+in the model summary, and the model will accept real data of any size there:
+
+```python
+import torch
+from torch import nn
+from pytorch_symbolic import Input, SymbolicModel
+
+inputs = Input(shape=(3, None, None))  # dynamic height and width
+assert inputs.shape == (1, 3, None, None)
+
+x = nn.Conv2d(in_channels=inputs.C, out_channels=16, kernel_size=3, padding=1)(inputs)
+model = SymbolicModel(inputs, x)
+
+outputs = model(torch.rand(2, 3, 32, 48))
+assert outputs.shape == (2, 16, 32, 48)
+```
+
+Under the hood, dynamic dimensions are traced with a placeholder size of 16.
+If the traced layers require larger inputs, increase it with
+`Input(shape=(3, None, None), dynamic_size_hint=64)`.
+Note that shapes of intermediate Symbolic Tensors are still reported with
+the placeholder size - only the input nodes display `None`.
 
 ### Sequential topology example
 

--- a/pytorch_symbolic/symbolic_data.py
+++ b/pytorch_symbolic/symbolic_data.py
@@ -319,17 +319,18 @@ class SymbolicTensor(SymbolicData):
         super().__init__(*args, **kwds)
         assert isinstance(self.v, torch.Tensor)
         self._shape = self.v.shape
+        self._dynamic_dims: set[int] = set()
 
     @property
-    def features(self) -> int:
+    def features(self) -> int | None:
         """Size of the last dimension."""
-        return self._shape[-1]
+        return self.shape[-1]
 
     @property
-    def C(self) -> int:
+    def C(self) -> int | None:
         """Number of channels in Image data."""
         assert len(self._shape) == 4, "The data is not of [C,H,W] form!"
-        return self._shape[1]
+        return self.shape[1]
 
     @property
     def channels(self) -> int:
@@ -337,16 +338,16 @@ class SymbolicTensor(SymbolicData):
         return self.C
 
     @property
-    def H(self) -> int:
+    def H(self) -> int | None:
         """Height in Image data."""
         assert len(self._shape) == 4, "The data is not of [C,H,W] form!"
-        return self._shape[2]
+        return self.shape[2]
 
     @property
-    def W(self) -> int:
+    def W(self) -> int | None:
         """Width in Image data."""
         assert len(self._shape) == 4, "The data is not of [C,H,W] form!"
-        return self._shape[3]
+        return self.shape[3]
 
     @property
     def HW(self) -> tuple[int, int]:
@@ -366,16 +367,24 @@ class SymbolicTensor(SymbolicData):
     @property
     def batch_size(self) -> int | None:
         """Batch size of the data. Will be default if was not provided."""
-        return self._shape[0]
+        return self.shape[0]
 
     @property
     def shape(self) -> tuple[int | None, ...]:
-        """Shape of the underlying Symbolic Tensor, including batch size."""
+        """Shape of the underlying Symbolic Tensor, including batch size.
+
+        Dimensions created with ``None`` in ``Input`` are dynamic and are returned as ``None``.
+        """
+        if self._dynamic_dims:
+            return tuple(None if idx in self._dynamic_dims else int(size) for idx, size in enumerate(self._shape))
         return self._shape
 
     @property
     def numel(self) -> int:
-        """Number of the values in underlying Symbolic Tensor. If batch size is known, it is used too."""
+        """Number of the values in underlying Symbolic Tensor. If batch size is known, it is used too.
+
+        Dynamic dimensions are counted with the placeholder size they were traced with.
+        """
         return self._shape.numel()
 
     # These methods do not need to be defined, because SymbolicData is redirecting __getattr__.
@@ -515,6 +524,7 @@ def Input(
     dtype=torch.float32,
     min_value: float = 0.0,
     max_value: float = 1.0,
+    dynamic_size_hint: int = 16,
 ) -> SymbolicTensor:
     """Input to Symbolic Model. Create Symbolic Tensor as a root node in the graph.
 
@@ -523,12 +533,16 @@ def Input(
     Parameters
     ----------
     shape
-        Shape of the real data NOT including the batch dimension
+        Shape of the real data NOT including the batch dimension.
+        A dimension can be ``None`` to mark it as dynamic, like in Keras:
+        it will be reported as ``None`` in ``.shape`` and in model summary,
+        and the real data can have any size there.
     batch_size
         Optional batch size of the Tensor
     batch_shape
         Shape of the real data including the batch dimension.
         If both ``shape`` and ``batch_shape`` are given, ``batch_shape`` has higher priority.
+        ``batch_shape[0]`` can be ``None`` to mark the batch size as unknown.
     dtype
         Dtype of the real data that will be the input of the network
     min_value
@@ -537,24 +551,39 @@ def Input(
         reasonable minimal value that the model can take as an input.
     max_value
         As above, but the maximal value
+    dynamic_size_hint
+        Placeholder size used during tracing for the dimensions marked as ``None``.
+        Increase it if the traced layers require larger inputs, e.g. for deep
+        downsampling stacks.
 
     Returns
     -------
     SymbolicTensor
         Root node in the graph
     """
+    assert dynamic_size_hint >= 1, "dynamic_size_hint must be a positive integer!"
     batch_size_known = True
+    dynamic_dims = set()
 
     if batch_shape is not None:
         batch_size = batch_shape[0]
         shape = batch_shape[1:]
+        if batch_size is None:
+            batch_size = 1
+            batch_size_known = False
+            dynamic_dims.add(0)
     else:
         # By default, we use batch_size of 1 under the hood
         batch_size_known = False
 
+    dynamic_dims.update(idx + 1 for idx, size in enumerate(shape) if size is None)
+    shape = tuple(dynamic_size_hint if size is None else size for size in shape)
+
     value = torch.rand(batch_size, *shape) * (max_value - min_value) + min_value
     value = value.to(dtype)
-    return SymbolicTensor(value=value, batch_size_known=batch_size_known)
+    symbolic_tensor = SymbolicTensor(value=value, batch_size_known=batch_size_known)
+    symbolic_tensor._dynamic_dims = dynamic_dims
+    return symbolic_tensor
 
 
 def CustomInput(data: Any) -> SymbolicData:

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -1,0 +1,80 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+import torch
+from torch import nn
+
+from pytorch_symbolic import Input, SymbolicModel
+
+
+def test_none_in_shape():
+    x = Input(shape=(None, 128))
+    assert x.shape == (1, None, 128)
+    assert tuple(x.v.shape) == (1, 16, 128)
+    assert x.features == 128
+
+
+def test_dynamic_size_hint():
+    x = Input(shape=(3, None, None), dynamic_size_hint=32)
+    assert tuple(x.v.shape) == (1, 3, 32, 32)
+    assert x.shape == (1, 3, None, None)
+    assert x.C == 3
+    assert x.H is None
+    assert x.W is None
+
+
+def test_batch_shape_with_none():
+    x = Input(batch_shape=(None, 10))
+    assert x.shape == (None, 10)
+    assert x.batch_size is None
+    assert not x.batch_size_known
+
+    y = Input(batch_shape=(4, 10))
+    assert tuple(y.shape) == (4, 10)
+    assert y.batch_size == 4
+    assert y.batch_size_known
+
+
+def test_static_input_unchanged():
+    x = Input(shape=(28, 28))
+    assert isinstance(x.shape, torch.Size)
+    assert tuple(x.shape) == (1, 28, 28)
+    assert x.batch_size == 1
+
+
+def test_model_runs_with_varied_sizes():
+    inputs = Input(shape=(3, None, None))
+    outputs = nn.Conv2d(3, 8, 3, padding=1)(inputs)
+    model = SymbolicModel(inputs=inputs, outputs=outputs)
+    for h, w in [(16, 16), (32, 48), (7, 9)]:
+        data = torch.rand(2, 3, h, w)
+        assert tuple(model(data).shape) == (2, 8, h, w)
+
+    inputs = Input(shape=(None, 64))
+    outputs = nn.Linear(64, 8)(inputs)
+    model = SymbolicModel(inputs=inputs, outputs=outputs)
+    for length in [1, 5, 100]:
+        data = torch.rand(2, length, 64)
+        assert tuple(model(data).shape) == (2, length, 8)
+
+
+def test_summary_and_input_shape():
+    inputs = Input(shape=(3, None, None))
+    outputs = nn.Conv2d(3, 8, 3, padding=1)(inputs)
+    model = SymbolicModel(inputs=inputs, outputs=outputs)
+
+    assert model.input_shape == (1, 3, None, None)
+    model.summary()
+
+
+def test_shape_index_fails_loudly():
+    x = Input(shape=(None, 64))
+    assert x.shape[1] is None
+
+    # Using a dynamic dimension as a layer size must fail at once
+    # instead of silently baking in the placeholder size
+    raised = False
+    try:
+        nn.Linear(x.shape[1], 4)
+    except TypeError:
+        raised = True
+    assert raised


### PR DESCRIPTION
This adds Keras-style dynamic dimensions to `Input`. In Keras you write `Input(shape=(None, 128))` to say "this dimension varies"; here you currently have to pass a concrete number, and the model then quietly accepts other sizes at runtime — so the reported shapes are misleading about what's actually fixed.

With this, you can mark a dimension as dynamic with `None`:

```python
inputs = Input(shape=(3, None, None))   # dynamic height and width
inputs.shape                            # (1, 3, None, None)
inputs.H, inputs.W                      # None, None

x = nn.Conv2d(inputs.C, 16, 3, padding=1)(inputs)
model = SymbolicModel(inputs, x)
model(torch.rand(2, 3, 32, 48))         # any H, W works
```

Details:

- Dynamic dims are reported as `None` in `.shape`, the shortcut properties (`.C/.H/.W/.features/.batch_size`) and `model.summary()` — same convention already used for unknown batch size.
- Tracing substitutes a placeholder size (default 16, configurable with the new `dynamic_size_hint` argument for deep downsampling stacks).
- `batch_shape=(None, ...)` marks the batch size as unknown explicitly.
- Inputs without any `None` are completely unaffected — `.shape` still returns the same `torch.Size`.
- Reporting `None` is intentionally the fail-loud choice: `nn.Linear(x.shape[1], ...)` on a dynamic dim now raises at trace time instead of silently baking the placeholder size into the layer.

One scope note: intermediate nodes still show the placeholder sizes they were traced with — only the input nodes report `None`. Propagating dynamic dims through layers is doable (trace twice with different placeholder sizes and diff) but it's a bigger change, so I left it out of this PR; happy to follow up if you're interested.

Includes 7 tests and a short docs section in `quick_start.md`.
