### PR TITLE
Warn when iterating a Symbolic Tensor with unknown batch size

### DIFF
--- a/pytorch_symbolic/symbolic_data.py
+++ b/pytorch_symbolic/symbolic_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Callable
 from types import MethodWrapperType
 from typing import Any
@@ -190,6 +191,14 @@ class SymbolicData:
 
         Suitable for unpacking results, even nested ones.
         """
+        if isinstance(self._value, torch.Tensor) and not self.batch_size_known:
+            msg = (
+                "Iterating over a Symbolic Tensor with unknown batch size! "
+                "This unpacks the placeholder batch dimension of size 1, "
+                "so exactly 1 node is yielded regardless of the real batch size. "
+                "If you meant to iterate over batch elements, create the input with `batch_shape=...`."
+            )
+            warnings.warn(msg, stacklevel=2)
         layer = useful_layers.UnpackLayer()
         new_outputs = layer.__call__(*self.v)
 

--- a/tests/test_iter_warning.py
+++ b/tests/test_iter_warning.py
@@ -1,0 +1,24 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+import warnings
+
+from pytorch_symbolic import Input
+
+
+def test_warns_when_iterating_unknown_batch():
+    x = Input(shape=(2, 8))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        nodes = list(x)
+
+    assert len(nodes) == 1  # the placeholder batch dimension is 1
+    assert any(issubclass(w.category, UserWarning) for w in caught)
+
+
+def test_no_warning_with_known_batch():
+    x = Input(batch_shape=(2, 8))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        a, b = x
+
+    assert len(caught) == 0


### PR DESCRIPTION
Iterating a Symbolic Tensor unpacks its underlying placeholder value. When the input was created without `batch_shape`, the placeholder batch dimension is 1, so `for row in symbolic_tensor:` silently yields exactly one element and bakes that count into the traced graph — regardless of the real batch size at runtime. It's almost never what you want, and it fails silently.

This adds a `UserWarning` when you iterate a tensor whose batch size is unknown, pointing at `batch_shape=` as the fix. Nothing else changes — known-batch iteration stays quiet (no existing test or docs example triggers it). 2 small tests included.
