### PR TITLE
Update check.sh to match current tooling (ruff)

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -4,17 +4,11 @@ echo "Running test suite for pytorch-symbolic!"
 echo "Optional dependencies are required. Install using 'pip install pytorch-symbolic[full]'"
 echo ""
 
-echo "Running isort..."
-isort .
+echo "Running ruff check..."
+ruff check . --fix || exit
 
-echo "Running black..."
-black .
-
-echo "Running flake8..."
-flake8 .
-
-echo "Running mypy..."
-mypy .
+echo "Running ruff format..."
+ruff format . || exit
 
 echo "Running pytest with the default settings..."
 pytest --no-header . || exit


### PR DESCRIPTION
`check.sh` still runs isort / black / flake8 / mypy, but since the build-system modernization (#30) the project standardized on ruff — `pyproject.toml` configures `[tool.ruff]` and CI runs `ruff check .` and `ruff format . --check`.

This brings the local script in line with CI: it now runs `ruff check . --fix` and `ruff format .` (keeping the auto-fixing behavior the old isort/black step had), followed by the same three pytest passes as before (default, `PYTORCH_SYMBOLIC_CODEGEN_MIN_LOOP_LENGTH=2`, `PYTORCH_SYMBOLIC_CODEGEN_BY_DEFAULT=False`). No more local-vs-CI drift.
