### PR TITLE
Speed up hash_torch_tensor by hashing raw bytes

### DIFF
--- a/pytorch_symbolic/model_tools.py
+++ b/pytorch_symbolic/model_tools.py
@@ -35,9 +35,15 @@ def model_similar(a: nn.Module, b: nn.Module):
 
 
 def hash_torch_tensor(tensor: torch.Tensor):
-    """Interpret the tensor as a string and return its hash."""
-    tensor_as_string = str(tensor.flatten().tolist())
-    return hash(tensor_as_string)
+    """Hash the tensor by its raw bytes, dtype and shape."""
+    try:
+        tensor_bytes = tensor.detach().cpu().contiguous().numpy().tobytes()
+    except (RuntimeError, TypeError):
+        # Numpy can be unavailable and some dtypes cannot be converted to numpy.
+        # Fall back to the much slower string representation.
+        tensor_as_string = str(tensor.flatten().tolist())
+        return hash(tensor_as_string)
+    return hash((str(tensor.dtype), tuple(tensor.shape), tensor_bytes))
 
 
 def models_have_corresponding_parameters(a: nn.Module, b: nn.Module):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 Szymon Mikler
+
+import torch
+from torch import nn
+
+from pytorch_symbolic import model_tools
+
+
+def test_hash_equal_for_equal_tensors():
+    a = torch.rand(16, 16)
+    b = a.clone()
+    assert model_tools.hash_torch_tensor(a) == model_tools.hash_torch_tensor(b)
+
+
+def test_hash_differs_for_different_values():
+    a = torch.zeros(4, 4)
+    b = torch.ones(4, 4)
+    assert model_tools.hash_torch_tensor(a) != model_tools.hash_torch_tensor(b)
+
+
+def test_corresponding_parameters_roundtrip():
+    torch.manual_seed(42)
+    a = nn.Linear(8, 4)
+    torch.manual_seed(42)
+    b = nn.Linear(8, 4)
+    assert model_tools.models_have_corresponding_parameters(a, b)
+
+    torch.manual_seed(43)
+    c = nn.Linear(8, 4)
+    assert not model_tools.models_have_corresponding_parameters(a, c)


### PR DESCRIPTION
`hash_torch_tensor` builds a string of the whole tensor before hashing it:

```python
tensor_as_string = str(tensor.flatten().tolist())
return hash(tensor_as_string)
```

That's `O(n)` Python-level work and gets slow for large parameter tensors (it's used by `models_have_corresponding_parameters`). This hashes the raw bytes together with dtype and shape instead, with a fallback to the old string path if the tensor can't be converted to numpy.

Equal tensors still hash equal — the property `models_have_corresponding_parameters` relies on — and it's now dtype/shape aware too. Added a few tests covering equality, difference, and the corresponding-parameters round-trip.
